### PR TITLE
feat: expose versionless id in output

### DIFF
--- a/.changes/unreleased/Changed-20250819-121939.yaml
+++ b/.changes/unreleased/Changed-20250819-121939.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Added versionless id to the output
+time: 2025-08-19T12:19:39.719298+02:00

--- a/README.md
+++ b/README.md
@@ -44,4 +44,5 @@ No modules.
 | <a name="output_secret_id"></a> [secret\_id](#output\_secret\_id) | n/a |
 | <a name="output_secret_name"></a> [secret\_name](#output\_secret\_name) | n/a |
 | <a name="output_secret_resource_id"></a> [secret\_resource\_id](#output\_secret\_resource\_id) | The secret resource id, includes the version of the secret |
+| <a name="output_secret_versionless_id"></a> [secret\_versionless\_id](#output\_secret\_versionless\_id) | The secret versionless id, can be used to auto rotate secrets |
 <!-- END_TF_DOCS -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,6 +7,11 @@ output "secret_resource_id" {
   description = "The secret resource id, includes the version of the secret"
 }
 
+output "secret_versionless_id" {
+  value       = azurerm_key_vault_secret.this.versionless_id
+  description = "The secret versionless id, can be used to auto rotate secrets"
+}
+
 output "secret_name" {
   value = azurerm_key_vault_secret.this.name
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 5.0"
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 4.11"
     }
     commercetools = {
       source = "labd/commercetools"


### PR DESCRIPTION
Azure should use the specified key vault secret version, when a secret is referenced in a container as environment variable. When updating this value, it can sometimes use an older (probably cached) version of the secret, which causes issues.

Not specifying the secret version should force Azure to always use the latest version. To allow this, as versionless secret id needs to be exposed.